### PR TITLE
CACAO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ k256 = { version = "0.9", default-features = false, features = ["std", "ecdsa", 
 sha3 = "0.9"
 thiserror = "1.0"
 url = "2.2"
+async-trait = "0.1"
+
+[dev-dependencies]
+async-std = { version = "1.10", features = ["attributes"] }

--- a/src/cacao.rs
+++ b/src/cacao.rs
@@ -1,0 +1,175 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use iri_string::types::{UriAbsoluteString, UriString};
+use std::{marker::PhantomData, str::FromStr};
+use thiserror::Error;
+use url::Host as GHost;
+
+pub type Host = GHost<String>;
+pub type TimeStamp = DateTime<Utc>;
+
+pub struct CACAO<S: SignatureScheme> {
+    pub h: Header,
+    pub p: Payload,
+    pub s: <<S as SignatureScheme>::SigType as SignatureType>::Signature,
+}
+
+pub struct Header {
+    t: String,
+}
+
+#[async_trait]
+pub trait SignatureScheme {
+    type SigType: SignatureType;
+    type RepOutput: Into<<<Self as SignatureScheme>::SigType as SignatureType>::Payload>;
+    type Rep: Representation<Output = Self::RepOutput>;
+    type Err;
+    fn id() -> String {
+        [Self::Rep::ID, "-", Self::SigType::ID].concat()
+    }
+    fn header() -> Header {
+        Header { t: Self::id() }
+    }
+    async fn verify(
+        payload: &CACAO<Self>,
+    ) -> Result<<<Self as SignatureScheme>::SigType as SignatureType>::Output, Self::Err>
+    where
+        Self: Sized;
+}
+
+#[derive(Default)]
+pub struct GenericScheme<R, S>(PhantomData<R>, PhantomData<S>);
+
+#[derive(Error, Debug)]
+pub enum VerificationError<S, E> {
+    // pub enum VerificationError<S: StdErr, E: StdErr> {
+    #[error("Verification Failed")]
+    Crypto,
+    #[error(transparent)]
+    Serialization(#[from] S),
+    #[error("Missing Payload Verification Material")]
+    MissingVerificationMaterial,
+    #[error(transparent)]
+    Custom(E),
+}
+
+#[async_trait]
+impl<R, S, P> SignatureScheme for GenericScheme<R, S>
+where
+    R: Representation<Output = P>,
+    S: SignatureType,
+    P: Into<S::Payload> + Send,
+    S::Signature: Sync + Send,
+    S::VerificationMaterial: Send + Sync,
+    S::Payload: Send + Sync,
+    R::Err: Send + Sync
+
+{
+    type Rep = R;
+    type SigType = S;
+    type RepOutput = P;
+    type Err = VerificationError<R::Err, ()>;
+    async fn verify(
+        payload: &CACAO<Self>,
+    ) -> Result<<<Self as SignatureScheme>::SigType as SignatureType>::Output, Self::Err>
+    where
+        Self: Sized,
+    {
+        Ok(Self::SigType::verify(
+            &Self::Rep::serialize(&payload.p)?.into(),
+            &Self::SigType::get_vmat(payload).ok_or(Self::Err::MissingVerificationMaterial)?,
+            &payload.s,
+        ).await
+        .map_err(|_| Self::Err::Crypto)?)
+    }
+}
+
+pub struct BasicSignature<S> {
+    pub s: S,
+}
+
+pub trait Representation {
+    const ID: &'static str;
+    type Err;
+    type Output;
+    fn serialize(payload: &Payload) -> Result<Self::Output, Self::Err>;
+}
+
+#[async_trait]
+pub trait SignatureType {
+    const ID: &'static str;
+    type Signature;
+    type Payload;
+    type VerificationMaterial;
+    type Output;
+    type Err;
+    async fn verify(
+        payload: &Self::Payload,
+        key: &Self::VerificationMaterial,
+        signature: &Self::Signature,
+    ) -> Result<Self::Output, Self::Err>;
+    fn get_vmat<S: SignatureScheme<SigType = Self>>(
+        payload: &CACAO<S>,
+    ) -> Option<Self::VerificationMaterial>;
+}
+
+#[derive(Copy, Clone)]
+pub enum Version {
+    V1 = 1,
+}
+
+#[derive(Clone)]
+pub struct Payload {
+    pub aud: Host,
+    pub exp: Option<String>,
+    pub iat: String,
+    pub iss: UriAbsoluteString,
+    pub nbf: Option<String>,
+    pub uri: UriAbsoluteString,
+    pub nonce: String,
+    pub version: Version,
+    pub requestId: Option<String>,
+    pub resources: Vec<UriString>,
+    pub statement: String,
+}
+
+impl Payload {
+    pub fn sign<S: SignatureScheme>(
+        self,
+        s: <<S as SignatureScheme>::SigType as SignatureType>::Signature,
+    ) -> CACAO<S> {
+        CACAO {
+            h: S::header(),
+            p: self,
+            s,
+        }
+    }
+
+    pub fn address<'a>(&'a self) -> Option<&'a str> {
+        self.iss.as_str().split(':').nth(4)
+    }
+
+    pub fn chain_id<'a>(&'a self) -> Option<&'a str> {
+        let rest = self.iss.as_str().strip_prefix("did:pkh:")?;
+        Some(rest.split_at(rest.rfind(':').unwrap_or(rest.len())).0)
+    }
+
+    pub fn iss<'a>(&'a self) -> &'a str {
+        &self.iss.as_str()
+    }
+
+    pub fn valid_now(&self) -> bool {
+        let now = Utc::now();
+        self.nbf
+            .as_ref()
+            .and_then(|s| TimeStamp::from_str(s).ok())
+            .map(|nbf| now >= nbf)
+            .unwrap_or(true)
+            && self
+                .exp
+                .as_ref()
+                .and_then(|s| TimeStamp::from_str(s).ok())
+                .map(|exp| now < exp)
+                .unwrap_or(true)
+    }
+}

--- a/src/cacao.rs
+++ b/src/cacao.rs
@@ -49,6 +49,8 @@ pub enum VerificationError<S, E> {
     Serialization(#[from] S),
     #[error("Missing Payload Verification Material")]
     MissingVerificationMaterial,
+    #[error("Not Currently Valid")]
+    NotCurrentlyValid,
     #[error(transparent)]
     Custom(E),
 }
@@ -75,6 +77,9 @@ where
     where
         Self: Sized,
     {
+        if !payload.p.valid_now() {
+            return Err(Self::Err::NotCurrentlyValid)
+        };
         Ok(Self::SigType::verify(
             &Self::Rep::serialize(&payload.p)?.into(),
             &Self::SigType::get_vmat(payload).ok_or(Self::Err::MissingVerificationMaterial)?,

--- a/src/eip191.rs
+++ b/src/eip191.rs
@@ -41,10 +41,8 @@ impl SignatureType for EIP191 {
         }
     }
 
-    fn get_vmat<S: SignatureScheme<SigType = Self>>(
-        payload: &CACAO<S>,
-    ) -> Option<Self::VerificationMaterial> {
-        match (payload.p.chain_id()?.get(..7), payload.p.address()) {
+    fn get_vmat(payload: &Payload) -> Option<Self::VerificationMaterial> {
+        match (payload.chain_id()?.get(..7), payload.address()) {
             (Some("eip155:"), Some(a)) => <Self::VerificationMaterial>::from_hex(&a[2..]).ok(),
             _ => None,
         }

--- a/src/eip191.rs
+++ b/src/eip191.rs
@@ -1,0 +1,78 @@
+use super::cacao::*;
+use async_trait::async_trait;
+use hex::FromHex;
+use k256::{
+    ecdsa::{
+        recoverable::{Id, Signature},
+        signature::Signature as S,
+        Error, Signature as Sig, VerifyingKey,
+    },
+    elliptic_curve::sec1::ToEncodedPoint,
+};
+use sha3::{Digest, Keccak256};
+
+pub struct EIP191;
+
+#[async_trait]
+impl SignatureType for EIP191 {
+    const ID: &'static str = "eip191";
+    type Payload = Vec<u8>;
+    type VerificationMaterial = [u8; 20];
+    type Signature = BasicSignature<[u8; 65]>;
+    type Err = Error;
+    type Output = VerifyingKey;
+    async fn verify(
+        payload: &Self::Payload,
+        address: &Self::VerificationMaterial,
+        signature: &Self::Signature,
+    ) -> Result<Self::Output, Self::Err> {
+        let vk = Signature::new(
+            &Sig::from_bytes(&signature.s[..64])?,
+            Id::new(&signature.s[64] % 27)?,
+        )?
+        .recover_verify_key(&get_eip191_bytes(payload))?;
+
+        if &Keccak256::default()
+            .chain(&vk.to_encoded_point(false).as_bytes()[1..])
+            .finalize()[12..] == address {
+            Ok(vk)
+        } else {
+            Err(Self::Err::new())
+        }
+    }
+
+    fn get_vmat<S: SignatureScheme<SigType = Self>>(
+        payload: &CACAO<S>,
+    ) -> Option<Self::VerificationMaterial> {
+        match (payload.p.chain_id()?.get(..7), payload.p.address()) {
+            (Some("eip155:"), Some(a)) => <Self::VerificationMaterial>::from_hex(&a[2..]).ok(),
+            _ => None,
+        }
+    }
+}
+
+pub fn get_eip191_bytes<P: AsRef<[u8]>>(payload: P) -> Vec<u8> {
+    [
+        format!("\x19Ethereum Signed Message:\n{}", &payload.as_ref().len()).as_bytes(),
+        &payload.as_ref(),
+    ]
+    .concat()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[async_std::test]
+    async fn validation() {
+        use hex::FromHex;
+        let message = r#"example EIP191 message"#.as_bytes().to_owned();
+        let addr = <[u8; 20]>::from_hex("a391f7add776806c4dff3886bbe6370be8f73683").unwrap();
+
+        let correct = BasicSignature { s: <[u8; 65]>::from_hex("7232514f3165922303f83abed772f193ab3e3767be5428e5df94821bbd250edd08e2970c873b9a43751ef001e6d8f09bafe057162162affcb4f6c1434bd948391c").unwrap() };
+        EIP191::verify(&message, &addr, &correct).await.unwrap();
+
+        let incorrect = BasicSignature { s: <[u8; 65]>::from_hex("8232514f3165922303f83abed772f193ab3e3767be5428e5df94821bbd250edd08e2970c873b9a43751ef001e6d8f09bafe057162162affcb4f6c1434bd948391c").unwrap() };
+        assert!(EIP191::verify(&message, &addr, &incorrect).await.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
+pub mod cacao;
+pub mod eip191;
 pub mod eip4361;
+pub mod siwe;

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -41,25 +41,25 @@ Issued At: 2021-11-12T17:37:48.462Z"#,
 
     #[async_std::test]
     async fn validation1() {
-        // from siwe tests, they're wrong w.r.t order of chain-id, nonce and iat??
+        // from siwe tests
         let message = from_str(
             r#"login.xyz wants you to sign in with your Ethereum account:
-0xe2f03cb7a54ddd886da9b0d227bfcb2d61429699
+0xb8a316ea8a9e48ebd25b73c71bc0f22f5c337d1f
 
 Sign-In With Ethereum Example Statement
 
 URI: https://login.xyz
 Version: 1
 Chain ID: 1
-Nonce: k13wuejc
-Issued At: 2021-11-12T17:37:48.462Z"#,
+Nonce: uolthxpe
+Issued At: 2021-11-25T02:36:37.013Z"#,
         )
         .unwrap();
-        let correct = <[u8; 65]>::from_hex(r#"795110331a07a4d475419fbdb346feb4c0579dcc8228989964474e07d98dbf425f38776cd6ca037f58288acc7b15e720c9cecac988479177fb70592f2391aaff1b"#).unwrap();
+        let correct = <[u8; 65]>::from_hex(r#"6eabbdf0861ca83b6cf98381dcbc3db16dffce9a0449dc8b359718d13b0093c3285b6dea7e84ad1aa4871b63899319a988ddf39df3080bcdc60f68dd0942e8221c"#).unwrap();
         WalletSIWE::verify(&message.clone().sign(BasicSignature { s: correct }))
             .await
             .unwrap();
-        let incorrect = <[u8; 65]>::from_hex(r#"895110331a07a4d475419fbdb346feb4c0579dcc8228989964474e07d98dbf425f38776cd6ca037f58288acc7b15e720c9cecac988479177fb70592f2391aaff1b"#).unwrap();
+        let incorrect = <[u8; 65]>::from_hex(r#"7eabbdf0861ca83b6cf98381dcbc3db16dffce9a0449dc8b359718d13b0093c3285b6dea7e84ad1aa4871b63899319a988ddf39df3080bcdc60f68dd0942e8221c"#).unwrap();
         assert!(
             WalletSIWE::verify(&message.sign(BasicSignature { s: incorrect }))
                 .await

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -26,18 +26,17 @@ Issued At: 2021-11-12T17:37:48.462Z"#,
         )
         .unwrap();
         let correct = <[u8; 65]>::from_hex(r#"40208c53a8939040a9b98edc7a523af4f2eff7ecac17796a9828be055d1e52de53ff813544652ecd7cdeddae01326d778728cb741835b3f135d6fb89865012cf1c"#).unwrap();
-        WalletSIWE::verify(&message.clone().sign(BasicSignature { s: correct }))
+        WalletSIWE::verify(&message.clone(), &BasicSignature { s: correct })
             .await
             .unwrap();
 
         let incorrect = <[u8; 65]>::from_hex(r#"50208c53a8939040a9b98edc7a523af4f2eff7ecac17796a9828be055d1e52de53ff813544652ecd7cdeddae01326d778728cb741835b3f135d6fb89865012cf1c"#).unwrap();
         assert!(
-            WalletSIWE::verify(&message.sign(BasicSignature { s: incorrect }))
+            WalletSIWE::verify(&message, &BasicSignature { s: incorrect })
                 .await
                 .is_err()
         );
     }
-
 
     #[async_std::test]
     async fn validation1() {
@@ -56,12 +55,12 @@ Issued At: 2021-11-25T02:36:37.013Z"#,
         )
         .unwrap();
         let correct = <[u8; 65]>::from_hex(r#"6eabbdf0861ca83b6cf98381dcbc3db16dffce9a0449dc8b359718d13b0093c3285b6dea7e84ad1aa4871b63899319a988ddf39df3080bcdc60f68dd0942e8221c"#).unwrap();
-        WalletSIWE::verify(&message.clone().sign(BasicSignature { s: correct }))
+        WalletSIWE::verify(&message, &BasicSignature { s: correct })
             .await
             .unwrap();
         let incorrect = <[u8; 65]>::from_hex(r#"7eabbdf0861ca83b6cf98381dcbc3db16dffce9a0449dc8b359718d13b0093c3285b6dea7e84ad1aa4871b63899319a988ddf39df3080bcdc60f68dd0942e8221c"#).unwrap();
         assert!(
-            WalletSIWE::verify(&message.sign(BasicSignature { s: incorrect }))
+            WalletSIWE::verify(&message, &BasicSignature { s: incorrect })
                 .await
                 .is_err()
         );

--- a/src/siwe.rs
+++ b/src/siwe.rs
@@ -1,0 +1,69 @@
+use super::{cacao::GenericScheme, eip191::EIP191, eip4361::EIP4361};
+
+pub type WalletSIWE = GenericScheme<EIP4361, EIP191>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cacao::*;
+    use crate::eip4361::from_str;
+    use hex::FromHex;
+
+    #[async_std::test]
+    async fn validation() {
+        // from https://github.com/blockdemy/eth_personal_sign
+        let message = from_str(
+            r#"login.xyz wants you to sign in with your Ethereum account:
+0x4b60ffaf6fd681abcc270faf4472011a4a14724c
+
+sign-In With Ethereum Example Statement
+
+URI: https://login.xyz
+Version: 1
+Chain ID: 1
+Nonce: k13wuejc
+Issued At: 2021-11-12T17:37:48.462Z"#,
+        )
+        .unwrap();
+        let correct = <[u8; 65]>::from_hex(r#"40208c53a8939040a9b98edc7a523af4f2eff7ecac17796a9828be055d1e52de53ff813544652ecd7cdeddae01326d778728cb741835b3f135d6fb89865012cf1c"#).unwrap();
+        WalletSIWE::verify(&message.clone().sign(BasicSignature { s: correct }))
+            .await
+            .unwrap();
+
+        let incorrect = <[u8; 65]>::from_hex(r#"50208c53a8939040a9b98edc7a523af4f2eff7ecac17796a9828be055d1e52de53ff813544652ecd7cdeddae01326d778728cb741835b3f135d6fb89865012cf1c"#).unwrap();
+        assert!(
+            WalletSIWE::verify(&message.sign(BasicSignature { s: incorrect }))
+                .await
+                .is_err()
+        );
+    }
+
+
+    #[async_std::test]
+    async fn validation1() {
+        // from siwe tests, they're wrong w.r.t order of chain-id, nonce and iat??
+        let message = from_str(
+            r#"login.xyz wants you to sign in with your Ethereum account:
+0xe2f03cb7a54ddd886da9b0d227bfcb2d61429699
+
+Sign-In With Ethereum Example Statement
+
+URI: https://login.xyz
+Version: 1
+Chain ID: 1
+Nonce: k13wuejc
+Issued At: 2021-11-12T17:37:48.462Z"#,
+        )
+        .unwrap();
+        let correct = <[u8; 65]>::from_hex(r#"795110331a07a4d475419fbdb346feb4c0579dcc8228989964474e07d98dbf425f38776cd6ca037f58288acc7b15e720c9cecac988479177fb70592f2391aaff1b"#).unwrap();
+        WalletSIWE::verify(&message.clone().sign(BasicSignature { s: correct }))
+            .await
+            .unwrap();
+        let incorrect = <[u8; 65]>::from_hex(r#"895110331a07a4d475419fbdb346feb4c0579dcc8228989964474e07d98dbf425f38776cd6ca037f58288acc7b15e720c9cecac988479177fb70592f2391aaff1b"#).unwrap();
+        assert!(
+            WalletSIWE::verify(&message.sign(BasicSignature { s: incorrect }))
+                .await
+                .is_err()
+        );
+    }
+}


### PR DESCRIPTION
Restructures the code around the [CACAO](https://github.com/ChainAgnostic/CAIPs/pull/74) model. It:
- abstracts the data into `CACAO` and `Payload` structs
- Separates serialization and verification into `Representation` and `SignatureType` traits
- implements `EIP4631` and `EIP191` for `Representation` and `SignatureType` traits respectively
- ideally, makes it easy to implement different CACAO types in future