### PR TITLE
Fix EIP-55 serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ hex = "0.4"
 k256 = { version = "0.9", default-features = false, features = ["std", "ecdsa", "keccak256"] }
 sha3 = "0.9"
 thiserror = "1.0"
-url = "2.2"
+ethers-core = "0.6.2"
+http = "0.2.5"


### PR DESCRIPTION
Also generalize `domain` to be an authority.

----

I didn't change the API from raw bytes, I don't think we need to.

I don't pass the chain ID to the checksum serializer, which could be a problem in the future.