### PR TITLE
use an integer for chain ID instead of string (as in EIP155)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub struct Message {
     pub statement: String,
     pub uri: UriString,
     pub version: Version,
-    pub chain_id: String,
+    pub chain_id: u64,
     pub nonce: String,
     pub issued_at: TimeStamp,
     pub expiration_time: Option<TimeStamp>,


### PR DESCRIPTION
closes #16, using a `u64` instead of `usize` just to avoid potential frustrations with platform-specific stuff when using `usize`