### PR TITLE
Switch to 2018 edition of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "siwe"
 version = "0.2.0"
 authors = ["Spruce Systems, Inc."]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Rust implementation of EIP-4361: Sign In With Ethereum"
 repository = "https://github.com/spruceid/siwe-rs/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,7 @@ const RES_TAG: &str = "Resources:";
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryInto;
     use hex::FromHex;
 
     #[test]


### PR DESCRIPTION
siwe-rs doesn't gain much from using 2021 edition, but switching to 2018 would lower MSRV and allow more people to use this library