### PR TITLE
Switch to the `time` crate for timestamp parsing and formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siwe"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -12,10 +12,10 @@ exclude = ["tests", ".github"]
 
 [dependencies]
 iri-string = "0.4"
-chrono = "0.4"
 hex = "0.4"
 k256 = { version = "0.9", default-features = false, features = ["std", "ecdsa", "keccak256"] }
 sha3 = "0.9"
+time = { version = "0.3", features = ["parsing", "formatting"] }
 thiserror = "1.0"
 http = "0.2.5"
 rand = "0.8.4"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This crate provides a pure Rust implementation of EIP-4361: Sign In With Ethereu
 SIWE can be easily installed in any Rust project by including it in said project's `cargo.toml` file:
 
 ``` toml
-siwe = "0.3"
+siwe = "0.4"
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ The time constraints (expiry and not-before) can also be validated, at current o
 if message.valid_now() { ... };
 
 // equivalent to
-if message.valid_at(&Utc::now()) { ... };
+if message.valid_at(&OffsetDateTime::now_utc()) { ... };
 ```
 
 Combined verification of time constraints and authentication can be done in a single call with `verify`:


### PR DESCRIPTION
`chrono` is currently flagged by https://github.com/advisories/GHSA-cqpr-pcm7-m3jc
the locatime-related code doesn't seem to be used,
so it's likely ok to switch to `time`.