### PR TITLE
WiP: Create a more ergonomic API for building/verifying messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siwe"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -23,3 +23,4 @@ rand = "0.8.4"
 [dev-dependencies]
 serde_json = "1.0"
 anyhow = "1.0"
+hex-literal = "0.3.4"


### PR DESCRIPTION
Let me preface this by saying this is a work in progress, and should absolutely not be used by anyone yet. There aren't any tests.

Now that that's out of the way, I would like to get your opinion on what I think is a more ergonomic API for building and verifying messages. If you like it, I'll polish it up!

Here's what using it would look like (from the doc comments in this PR):

## Building a Message

```rust
use siwe::SignInWithEthereum;
use siwe::nonce::generate_nonce;

// `SignInWithEthereum` is the main entry point for both building and validation.
SignInWithEthereum::default()

    // Common options for both building and validating messages:
    .uri("https://example.com:4337/sign-in")?
    .statement("Hello, World")
    .chain_id(1337)

    // Indicate that we want to build a message (not validate one.)
    .builder()?

    // Specific options for generating a message:
    .nonce(generate_nonce())
    .address([0u8; 20])
    .add_resource("https://example.com/u/1234")?
    .build()?


/*
Which would generate a message like:

example.com:4337 wants you to sign in with your Ethereum account:
0x0000000000000000000000000000000000000000

Hello, World

URI: https://example.com:4337/sign-in
Version: 1
Chain ID: 1337
Nonce: lU0FgHkI6hO
Issued At: 1970-01-01T00:00:00Z
Resources:
- https://example.com/u/1234

*/
```

## Verifying a Message

```rust
use hex_literal::hex;

use siwe::{SignInWithEthereum, Verify};

use time::OffsetDateTime;


const MESSAGE: &str = r#"localhost wants you to sign in with your Ethereum account:
0x4b60ffAf6fD681AbcC270Faf4472011A4A14724C

Allow localhost to access your orbit using their temporary session key: did:key:z6Mktud6LcDFb3heS7FFWoJhiCafmUPkCAgpvJLv5E6fgBJg#z6Mktud6LcDFb3heS7FFWoJhiCafmUPkCAgpvJLv5E6fgBJg

URI: did:key:z6Mktud6LcDFb3heS7FFWoJhiCafmUPkCAgpvJLv5E6fgBJg#z6Mktud6LcDFb3heS7FFWoJhiCafmUPkCAgpvJLv5E6fgBJg
Version: 1
Chain ID: 1
Nonce: PPrtjztx2lYqWbqNs
Issued At: 2021-12-20T12:29:25.907Z
Expiration Time: 2021-12-20T12:44:25.906Z
Resources:
- kepler://bafk2bzacecn2cdbtzho72x4c62fcxvcqj23padh47s5jyyrv42mtca3yrhlpa#put
- kepler://bafk2bzacecn2cdbtzho72x4c62fcxvcqj23padh47s5jyyrv42mtca3yrhlpa#del
- kepler://bafk2bzacecn2cdbtzho72x4c62fcxvcqj23padh47s5jyyrv42mtca3yrhlpa#get
- kepler://bafk2bzacecn2cdbtzho72x4c62fcxvcqj23padh47s5jyyrv42mtca3yrhlpa#list"#;

const SIGNATURE: [u8; 65] = hex!("20c0da863b3dbfbb2acc0fb3b9ec6daefa38f3f20c997c283c4818ebeca96878787f84fccc25c4087ccb31ebd782ae1d2f74be076a49c0a8604419e41507e9381c");

// `SignInWithEthereum` is the main entry point for both building and validation.
let verifier = SignInWithEthereum::default()

    // Common options for both building and validating messages:
    .domain("localhost")?
    .uri("did:key:z6Mktud6LcDFb3heS7FFWoJhiCafmUPkCAgpvJLv5E6fgBJg#z6Mktud6LcDFb3heS7FFWoJhiCafmUPkCAgpvJLv5E6fgBJg")?
    .chain_id(1)

    // Indicate that we want to verify a message (not build one.)
    .verifier(MESSAGE)?

    // Optionally pick a custom time, or leave it as the current time.
    .valid_at(OffsetDateTime::from_unix_timestamp(1640003425)?)

    // Customize which fields to verify (or leave the defaults.)
    .statement(Verify::Never);

// It is important to check that this message's nonce has never been used.
let nonce = check_for_nonce_reuse(verifier.nonce())?;

verifier
    .verify(&nonce, &SIGNATURE)?
```