### PR TITLE
Add support for EIP1271 contract wallets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,11 +14,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: Build
-      run: cargo build --verbose
-    - name: Clippy
-      run: RUSTFLAGS="-Dwarnings" cargo clippy
+    - uses: taiki-e/install-action@cargo-hack
+    - name: Check
+      run: cargo hack check --optional-deps --feature-powerset --no-dev-deps
+    - name: Run tests
+      run: cargo hack test --optional-deps --feature-powerset
     - name: Fmt
       run: cargo fmt -- --check
-    - name: Run tests
-      run: cargo test --verbose
+    - name: Clippy
+      run: RUSTFLAGS="-Dwarnings" cargo hack clippy --optional-deps --feature-powerset

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ thiserror = "1.0"
 http = "0.2.5"
 rand = "0.8.4"
 serde = { version = "1.0.140", optional = true }
+ethers = { version = "0.17.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
 anyhow = "1.0"
+tokio = { version = "1.21.1", features = ["rt", "macros"] }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ let message: Message = string_message.parse()?;
 Verification and Authentication is performed via EIP-191, using the `address` field of the `Message` as the expected signer. This returns the Ethereum public key of the signer:
 
 ``` rust
-let signer: Vec<u8> = message.verify_eip191(&signature)?;
+let signer: Vec<u8> = message.verify_eip191(&signature).await?;
 ```
 
 The time constraints (expiry and not-before) can also be validated, at current or particular times:
@@ -42,7 +42,7 @@ if message.valid_at(&OffsetDateTime::now_utc()) { ... };
 Combined verification of time constraints and authentication can be done in a single call with `verify`:
 
 ``` rust
-let signer: Vec<u8> = message.verify(&signature)?;
+let signer: Vec<u8> = message.verify(&signature).await?;
 ```
 
 ### Serialization of a SIWE Message
@@ -73,17 +73,17 @@ Parsing and verifying a `Message` is easy:
 let message: Message = str.parse()?;
 let signature: [u8; 65];
 
-if let Err(e) = message.verify(&signature) {
+if let Err(e) = message.verify(&signature).await {
     // message cannot be correctly authenticated at this time
 }
 
 // do application-specific things
 ```
 
-## Disclaimer 
+## Disclaimer
 
-Our Rust library for Sign-In with Ethereum has not yet undergone a formal security 
-audit. We welcome continued feedback on the usability, architecture, and security 
+Our Rust library for Sign-In with Ethereum has not yet undergone a formal security
+audit. We welcome continued feedback on the usability, architecture, and security
 of this implementation.
 
 ## See Also

--- a/src/eip1271.rs
+++ b/src/eip1271.rs
@@ -1,0 +1,69 @@
+use std::{collections::BTreeMap, convert::TryFrom};
+
+use ethers::{
+    abi::{Abi, Function, Param, ParamType, StateMutability},
+    contract::{AbiError, Contract},
+    prelude::*,
+};
+
+use crate::VerificationError;
+
+const METHOD_NAME: &str = "isValidSignature";
+
+pub async fn verify_eip1271(
+    address: [u8; 20],
+    message_hash: &[u8; 32],
+    signature: &[u8],
+) -> Result<bool, VerificationError> {
+    #[allow(deprecated)]
+    let abi = Abi {
+        constructor: None,
+        functions: BTreeMap::from([(
+            "isValidSignature".to_string(),
+            vec![Function {
+                name: "isValidSignature".to_string(),
+                inputs: vec![
+                    Param {
+                        name: " _message".to_string(),
+                        kind: ParamType::FixedBytes(32),
+                        internal_type: Some("bytes32".to_string()),
+                    },
+                    Param {
+                        name: " _signature".to_string(),
+                        kind: ParamType::Bytes,
+                        internal_type: Some("bytes".to_string()),
+                    },
+                ],
+                outputs: vec![Param {
+                    name: "".to_string(),
+                    kind: ParamType::FixedBytes(4),
+                    internal_type: Some("bytes4".to_string()),
+                }],
+                constant: None,
+                state_mutability: StateMutability::View,
+            }],
+        )]),
+        events: BTreeMap::new(),
+        errors: BTreeMap::new(),
+        receive: false,
+        fallback: false,
+    };
+
+    let client = Provider::<Http>::try_from("https://cloudflare-eth.com")
+        .map_err(|e| VerificationError::Provider(e.to_string()))?;
+    let contract = Contract::new(address.into(), abi, client);
+
+    match contract
+        .method::<_, [u8; 4]>(
+            METHOD_NAME,
+            (*message_hash, Bytes::from(signature.to_owned())),
+        )
+        .unwrap()
+        .call()
+        .await
+    {
+        Ok(r) => Ok(r == [22, 38, 186, 126]),
+        Err(ContractError::AbiError(AbiError::DecodingError(_))) => Ok(false),
+        Err(e) => Err(VerificationError::ContractCall(e.to_string())),
+    }
+}


### PR DESCRIPTION
- Makes the `verify` function async.
- Functionality is behind non-default ethers feature.
- Currently non-configurable until the `verify` function accepts an options struct.

Close #33