### PR TITLE
Bump `http` to `1.0.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ k256 = { version = "0.13", default-features = false, features = [
 sha3 = "0.10.8"
 time = { version = "0.3", features = ["parsing", "formatting"] }
 thiserror = "1.0"
-http = "0.2.9"
+http = "1.0.0"
 rand = "0.8.5"
 serde = { version = "1.0.164", optional = true }
 ethers = { version = "2.0.7", optional = true }


### PR DESCRIPTION
This PR bumps the `http` version to `1.0.0`. 