### PR TITLE
Alloy Migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ http = "1.0.0"
 rand = "0.8.5"
 serde = { version = "1.0.164", optional = true }
 typed-builder = { version = "0.14.0", optional = true }
-alloy = { version = "0.2", optional = true, features = ["full"]}
+alloy = { version = "0.2", optional = true, features = ["default", "providers", "sol-types", "contract"]}
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ http = "1.0.0"
 rand = "0.8.5"
 serde = { version = "1.0.164", optional = true }
 typed-builder = { version = "0.14.0", optional = true }
-alloy = { version = "0.2", optional = true, features = ["default", "providers", "sol-types", "contract"]}
+alloy = { version = "0.2", optional = true, features = ["providers", "sol-types", "contract"]}
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siwe"
-version = "0.6.1"
+version = "7.0.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siwe"
-version = "7.0.0"
+version = "1.0.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ http = "1.0.0"
 rand = "0.8.5"
 serde = { version = "1.0.164", optional = true }
 typed-builder = { version = "0.14.0", optional = true }
-alloy = { version = "0.2", optional = true, features = ["providers", "sol-types", "contract"]}
+alloy = { version = "1.0", optional = true, features = ["providers", "sol-types", "contract"]}
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ http = "1.0.0"
 rand = "0.8.5"
 serde = { version = "1.0.164", optional = true }
 typed-builder = { version = "0.14.0", optional = true }
-alloy = { version = "0.12.5", optional=true }
+alloy = { version = "0.2", optional = true, features = ["full"]}
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,13 @@
 name = "siwe"
 version = "0.6.1"
 authors = ["Spruce Systems, Inc."]
-edition = "2018"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Rust implementation of EIP-4361: Sign In With Ethereum"
 repository = "https://github.com/spruceid/siwe-rs/"
 exclude = ["tests", ".github"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 
 [dependencies]
 iri-string = "0.7"
@@ -24,8 +23,8 @@ thiserror = "1.0"
 http = "1.0.0"
 rand = "0.8.5"
 serde = { version = "1.0.164", optional = true }
-ethers = { version = "2.0.7", optional = true }
 typed-builder = { version = "0.14.0", optional = true }
+alloy = { version = "0.12.5", optional=true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ siwe = "0.6"
 
 Features available:
 - `serde` for serialisation/deserialisation support;
-- `ethers` for EIP-1271 compliant contract wallets support; and
+- `alloy` for EIP-1271 compliant contract wallets support; and
 - `typed-builder` for nicer verification options construction.
 
 ## Usage

--- a/src/eip1271.rs
+++ b/src/eip1271.rs
@@ -1,68 +1,71 @@
-use std::collections::BTreeMap;
-
-use ethers::{
-    abi::{Abi, Function, Param, ParamType, StateMutability},
-    contract::{AbiError, ContractInstance},
-    prelude::*,
+use ERC1271::isValidSignatureReturn;
+use alloy::{
+    primitives::{Address, Bytes, FixedBytes},
+    sol,
 };
 
 use crate::VerificationError;
 
-const METHOD_NAME: &str = "isValidSignature";
+pub type AlloyProvider = alloy::providers::fillers::FillProvider<
+    alloy::providers::fillers::JoinFill<
+        alloy::providers::Identity,
+        alloy::providers::fillers::JoinFill<
+            alloy::providers::fillers::GasFiller,
+            alloy::providers::fillers::JoinFill<
+                alloy::providers::fillers::BlobGasFiller,
+                alloy::providers::fillers::JoinFill<
+                    alloy::providers::fillers::NonceFiller,
+                    alloy::providers::fillers::ChainIdFiller,
+                >,
+            >,
+        >,
+    >,
+    alloy::providers::RootProvider,
+>;
+
+sol! {
+    #[sol(rpc)]
+    contract ERC1271 {
+      /// bytes4(keccak256("isValidSignature(bytes32,bytes)")
+      bytes4 constant internal MAGICVALUE = 0x1626ba7e;
+
+      /// /**
+      ///  * @dev Should return whether the signature provided is valid for the provided hash
+      ///  * @param _hash      Hash of the data to be signed
+      ///  * @param _signature Signature byte array associated with _hash
+      ///  *
+      ///  * MUST return the bytes4 magic value 0x1626ba7e when function passes.
+      ///  * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
+      ///  * MUST allow external calls
+      ///  */
+      function isValidSignature(
+        bytes32 _hash,
+        bytes memory _signature)
+        public
+        view
+        returns (bytes4 magicValue);
+    }
+}
 
 pub async fn verify_eip1271(
-    address: [u8; 20],
-    message_hash: &[u8; 32],
-    signature: &[u8],
-    provider: &Provider<Http>,
+    address: Address,
+    message_hash: FixedBytes<32>,
+    signature: Bytes,
+    provider: &AlloyProvider,
 ) -> Result<bool, VerificationError> {
-    #[allow(deprecated)]
-    let abi = Abi {
-        constructor: None,
-        functions: BTreeMap::from([(
-            METHOD_NAME.to_string(),
-            vec![Function {
-                name: METHOD_NAME.to_string(),
-                inputs: vec![
-                    Param {
-                        name: " _message".to_string(),
-                        kind: ParamType::FixedBytes(32),
-                        internal_type: Some("bytes32".to_string()),
-                    },
-                    Param {
-                        name: " _signature".to_string(),
-                        kind: ParamType::Bytes,
-                        internal_type: Some("bytes".to_string()),
-                    },
-                ],
-                outputs: vec![Param {
-                    name: "".to_string(),
-                    kind: ParamType::FixedBytes(4),
-                    internal_type: Some("bytes4".to_string()),
-                }],
-                constant: None,
-                state_mutability: StateMutability::View,
-            }],
-        )]),
-        events: BTreeMap::new(),
-        errors: BTreeMap::new(),
-        receive: false,
-        fallback: false,
-    };
-
-    let contract = ContractInstance::<&Provider<Http>, Provider<Http>>::new(address, abi, provider);
-
-    match contract
-        .method::<_, [u8; 4]>(
-            METHOD_NAME,
-            (*message_hash, Bytes::from(signature.to_owned())),
-        )
-        .unwrap()
+    let contract = ERC1271::new(address, provider);
+    let res = contract
+        .isValidSignature(message_hash, signature)
         .call()
-        .await
-    {
-        Ok(r) => Ok(r == [22, 38, 186, 126]),
-        Err(ContractError::AbiError(AbiError::DecodingError(_))) => Ok(false),
-        Err(e) => Err(VerificationError::ContractCall(e.to_string())),
+        .await;
+    match res {
+        Ok(isValidSignatureReturn {
+            magicValue: FixedBytes([22, 38, 186, 126]),
+        }) => Ok(true),
+        Ok(isValidSignatureReturn {
+            magicValue: FixedBytes([255, 255, 255, 255]),
+        }) => Ok(false),
+        Ok(_) => Err(VerificationError::Eip1271NonCompliant)?,
+        Err(e) => Err(VerificationError::ContractCall(e.to_string()))?,
     }
 }

--- a/src/eip1271.rs
+++ b/src/eip1271.rs
@@ -1,27 +1,14 @@
 use ERC1271::isValidSignatureReturn;
 use alloy::{
     primitives::{Address, Bytes, FixedBytes},
+    providers::RootProvider,
     sol,
+    transports::http::{Client, Http},
 };
 
 use crate::VerificationError;
 
-pub type AlloyProvider = alloy::providers::fillers::FillProvider<
-    alloy::providers::fillers::JoinFill<
-        alloy::providers::Identity,
-        alloy::providers::fillers::JoinFill<
-            alloy::providers::fillers::GasFiller,
-            alloy::providers::fillers::JoinFill<
-                alloy::providers::fillers::BlobGasFiller,
-                alloy::providers::fillers::JoinFill<
-                    alloy::providers::fillers::NonceFiller,
-                    alloy::providers::fillers::ChainIdFiller,
-                >,
-            >,
-        >,
-    >,
-    alloy::providers::RootProvider,
->;
+pub type AlloyProvider<Client> = RootProvider<Http<Client>>;
 
 sol! {
     #[sol(rpc)]
@@ -51,7 +38,7 @@ pub async fn verify_eip1271(
     address: Address,
     message_hash: FixedBytes<32>,
     signature: Bytes,
-    provider: &AlloyProvider,
+    provider: &AlloyProvider<Client>,
 ) -> Result<bool, VerificationError> {
     let contract = ERC1271::new(address, provider);
     let res = contract

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,11 @@ use ::core::{
     str::FromStr,
 };
 #[cfg(feature = "alloy")]
-use alloy::primitives::{Address, Bytes, FixedBytes};
+use alloy::{
+    primitives::{Address, Bytes, FixedBytes},
+    transports::http::Client,
+};
+
 use hex::FromHex;
 use http::uri::{Authority, InvalidUri};
 use iri_string::types::UriString;
@@ -345,7 +349,7 @@ typed_builder_doc! {
         pub timestamp: Option<OffsetDateTime>,
         #[cfg(feature = "alloy")]
         /// RPC Provider used for on-chain checks. Necessary for contract wallets signatures.
-        pub rpc_provider: Option<AlloyProvider>,
+        pub rpc_provider: Option<AlloyProvider<Client>>,
     }
 }
 
@@ -472,7 +476,7 @@ impl Message {
     pub async fn verify_eip1271(
         &self,
         sig: &[u8],
-        provider: &AlloyProvider,
+        provider: &AlloyProvider<Client>,
     ) -> Result<bool, VerificationError> {
         let hash = Keccak256::new_with_prefix(self.eip191_bytes().unwrap()).finalize();
         eip1271::verify_eip1271(

--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -1,5 +1,5 @@
 use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::{Rng, thread_rng};
 
 /// Generates a secure nonce.
 pub fn generate_nonce() -> String {

--- a/src/rfc3339.rs
+++ b/src/rfc3339.rs
@@ -3,7 +3,7 @@ use core::{
     fmt::{self, Display, Formatter},
     str::FromStr,
 };
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Wrapper for [OffsetDateTime], meant to enable transitivity of deserialisation and serialisation.


### PR DESCRIPTION
GM, this PR updates the crate to use the successor of Ethers, Alloy, and bumps the edition to 2024. 

- Ethers-rs was officially archived by its author on October 18th, 2024 
- And marked deprecated https://github.com/gakonst/ethers-rs/issues/2667 
- Links and closes #55 